### PR TITLE
Added logic to handle scenarios when views is set to an array

### DIFF
--- a/example-partials/app.js
+++ b/example-partials/app.js
@@ -1,0 +1,30 @@
+var express = require('express')
+var app = express()
+var path = require('path')
+
+var dust = require('../index')
+
+dust._.optimizers.format = function (ctx, node) {
+    return node
+}
+
+app.set('view engine', 'dust')
+app.set('views', [
+    path.resolve(__dirname, './views'),
+    path.resolve(__dirname, './views/partials')
+])
+
+app.get('/partial-example', function (req, res) {
+    res.render('partial-example', {
+        title: 'Hello world',
+        name: 'Joe',
+        sentence: 'The quick brown fox jumps over the lazy dog',
+        number: req.query.number || 0
+    })
+})
+
+app.get('/error', function (req, res) {
+    res.render('error')
+})
+
+app.listen(3001)

--- a/example-partials/app.js
+++ b/example-partials/app.js
@@ -8,20 +8,31 @@ dust._.optimizers.format = function (ctx, node) {
     return node
 }
 
+app.engine('dust', dust.engine())
 app.set('view engine', 'dust')
 app.set('views', [
     path.resolve(__dirname, './views'),
+    path.resolve(__dirname, './views/layouts'),
     path.resolve(__dirname, './views/partials')
 ])
 
-app.get('/partial-example', function (req, res) {
-    res.render('partial-example', {
-        title: 'Hello world',
-        name: 'Joe',
-        sentence: 'The quick brown fox jumps over the lazy dog',
-        number: req.query.number || 0
+app
+    .get('/', function (req, res) {
+        res.render('index', {
+            title: 'Login'
+        })
     })
-})
+    .post('/', function(req, res) {
+        res.redirect('/home')
+    })
+    .get('/home', function(req, res) {
+        res.render('home', {
+            title: 'Home',
+            name: 'Joe',
+            sentence: 'the quick brown fox jumps over the lazy dog',
+            number: req.query.number || 0
+        })
+    })
 
 app.get('/error', function (req, res) {
     res.render('error')

--- a/example-partials/views/home.dust
+++ b/example-partials/views/home.dust
@@ -1,0 +1,11 @@
+{>"authorized" /}
+
+{<header}
+    {> "header" /}
+{/header}
+{<body}
+    This is the home page
+{/body}
+{<footer}
+    {> "footer" /}
+{/footer}

--- a/example-partials/views/index.dust
+++ b/example-partials/views/index.dust
@@ -1,0 +1,15 @@
+{>"unauthorized" /}
+
+{<body}
+<form method="post">
+    <div>
+        <label for="username">Username:</label>
+        <input name="username" type="text" />
+    </div>
+    <div>
+        <label for="password">Password:</label>
+        <input name="password" type="text" />
+    </div>
+    <button>Submit</button>
+</form>
+{/body}

--- a/example-partials/views/layouts/authorized.dust
+++ b/example-partials/views/layouts/authorized.dust
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{title}</title>
+    <meta charset="UTF-8"/>
+</head>
+<body>
+
+{+header}
+    <header>
+        <h1>Default Header</h1>
+    </header>
+{/header}
+{+body /}
+{+footer}
+    <footer>
+        Default Footer
+    </footer>
+{/footer}
+</body>
+</html>

--- a/example-partials/views/layouts/unauthorized.dust
+++ b/example-partials/views/layouts/unauthorized.dust
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{title}</title>
+    <meta charset="UTF-8"/>
+</head>
+<body>
+{+body /}
+</body>
+</html>

--- a/example-partials/views/partials/footer.dust
+++ b/example-partials/views/partials/footer.dust
@@ -1,0 +1,3 @@
+<footer>
+    Did you know that {sentence}?
+</footer>

--- a/example-partials/views/partials/header.dust
+++ b/example-partials/views/partials/header.dust
@@ -1,0 +1,3 @@
+<header>
+    <h1>Welcome back {name}!</h1>
+</header>

--- a/example-partials/views/partials/partial.dust
+++ b/example-partials/views/partials/partial.dust
@@ -1,0 +1,1 @@
+<h2>Hello, {name}!</h2>

--- a/index.js
+++ b/index.js
@@ -52,7 +52,22 @@ Object.defineProperty(module.exports, 'engine', {
       }
 
       dust.onLoad = function (name, callback) {
-        var content = fs.readFileSync(path.resolve(options.settings.views, name) + ext).toString()
+        var content;
+
+        if(options.settings.views instanceof String) {
+          content = fs.readFileSync(path.resolve(options.settings.views, name) + ext).toString();
+        }
+        else {
+          var filePaths = path.resolve(options.settings.views + name + ext);
+          filePaths = filePaths.split(',');
+          for(var i = 0; i < filePaths.length; i++) {
+            if(filePaths[i].indexOf(ext) != -1) {
+              content = fs.readFileSync(filePaths[i]).toString();
+              break;
+            }
+          }
+        }
+
         callback(null, content)
       }
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ Object.defineProperty(module.exports, 'engine', {
       dust.onLoad = function (name, callback) {
         var content;
 
-        if(typeof options.settings.views == 'string') {
+        if(typeof options.settings.views === 'string') {
           content = fs.readFileSync(path.resolve(options.settings.views, name) + ext).toString();
         }
         else {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ Object.defineProperty(module.exports, 'engine', {
           var filePaths = path.resolve(options.settings.views + name + ext);
           filePaths = filePaths.split(',');
           for(var i = 0; i < filePaths.length; i++) {
-            if(filePaths[i].indexOf(ext) != -1) {
+            if(filePaths[i].indexOf(ext) !== -1) {
               content = fs.readFileSync(filePaths[i]).toString();
               break;
             }

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ Object.defineProperty(module.exports, 'engine', {
       dust.onLoad = function (name, callback) {
         var content;
 
-        if(options.settings.views instanceof String) {
+        if(typeof options.settings.views == 'string') {
           content = fs.readFileSync(path.resolve(options.settings.views, name) + ext).toString();
         }
         else {

--- a/index.js
+++ b/index.js
@@ -52,18 +52,19 @@ Object.defineProperty(module.exports, 'engine', {
       }
 
       dust.onLoad = function (name, callback) {
-        var content;
+        var content
 
         if(typeof options.settings.views === 'string') {
-          content = fs.readFileSync(path.resolve(options.settings.views, name) + ext).toString();
+          content = fs.readFileSync(path.resolve(options.settings.views, name) + ext).toString()
         }
         else {
-          var filePaths = path.resolve(options.settings.views + name + ext);
-          filePaths = filePaths.split(',');
-          for(var i = 0; i < filePaths.length; i++) {
-            if(filePaths[i].indexOf(ext) !== -1) {
-              content = fs.readFileSync(filePaths[i]).toString();
-              break;
+          var viewPaths = options.settings.views
+
+          for(var i = 0; i < viewPaths.length; i++) {
+            var viewPath =  path.resolve(viewPaths[i], name) + ext
+            if(fs.existsSync(viewPath)) {
+              content = fs.readFileSync(viewPath).toString()
+              break
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "DustJS middleware for ExpressJS",
   "main": "index.js",
   "scripts": {
-    "gulp": "./node_modules/gulp/bin/gulp.js",
+    "gulp": "node ./node_modules/gulp/bin/gulp.js",
     "mocha": "node --harmony node_modules/mocha/bin/_mocha --reporter nyan --bail --check-leaks test/*.js",
     "mocha:cov": "node --harmony node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- --reporter spec --check-leaks test/*.js",
     "test": "npm run gulp && npm run mocha",
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/chrisyip/express-dustjs",
   "dependencies": {
-    "dustjs-helpers": "^1.5.0",
-    "dustjs-linkedin": "^2.5.1",
+    "dustjs-helpers": "1.5.0",
+    "dustjs-linkedin": "2.5.1",
     "lodash": "^2.4.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ var Promise = require('bluebird')
 /* jshint +W079 */
 
 require('../example/app.js')
+require('../example-partials/app.js')
 
 function req (url, cb) {
   return request.get('http://localhost:3000/' + url, cb)
@@ -17,6 +18,14 @@ function req (url, cb) {
 describe('dust', function () {
   it('should work', function (done) {
     req('', function (err, response, body) {
+      assert.equal(response.statusCode, 200)
+      assert.equal(body.indexOf('Hello world') > -1, true)
+      done()
+    })
+  })
+
+  it('should work when views is set to an array', function(done) {
+    request.get('http://localhost:3001/partial-example', function(err, response, body) {
       assert.equal(response.statusCode, 200)
       assert.equal(body.indexOf('Hello world') > -1, true)
       done()

--- a/test/index.js
+++ b/test/index.js
@@ -25,9 +25,10 @@ describe('dust', function () {
   })
 
   it('should work when views is set to an array', function(done) {
-    request.get('http://localhost:3001/partial-example', function(err, response, body) {
+    request.get('http://localhost:3001/home', function(err, response, body) {
+      console.log(response.statusCode);
       assert.equal(response.statusCode, 200)
-      assert.equal(body.indexOf('Hello world') > -1, true)
+      assert.equal(body.indexOf('Welcome back') > -1, true)
       done()
     })
   })


### PR DESCRIPTION
If the views setting of Express is set to an Array, path.resolve will throw new TypeError('Arguments to path.resolve must be strings') and so I made adjustments to accommodate for that scenario.
